### PR TITLE
coriander: fix compiler error

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,10 +9,11 @@ option(UNIT_TEST "Build tests" OFF)
 
 cmake_minimum_required(VERSION 3.13.1)
 if (UNIT_TEST)
-    set(CMAKE_CXX_STANDARD 20)
 else ()
     find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 endif (UNIT_TEST)
+
+set(CMAKE_CXX_STANDARD 20)
 
 project(app LANGUAGES C CXX)
 


### PR DESCRIPTION
to check coriander doesn't have any backend code,
I created a dummy target but not assign a cxx standard.